### PR TITLE
Add .env example and env-based supabase config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Example environment configuration for Mia Consent Offline Form
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+
+# Optional build metadata
+VITE_APP_ENV=
+VITE_APP_VERSION=
+
+# EmailJS integration (if used)
+VITE_EMAILJS_SERVICE_ID=
+VITE_EMAILJS_TEMPLATE_ID=
+VITE_EMAILJS_PUBLIC_KEY=

--- a/README.md
+++ b/README.md
@@ -135,10 +135,17 @@ The app includes a comprehensive PWA manifest with:
 ## Configuration
 
 ### Environment Variables
-Create a `.env` file for production deployment:
+Copy `.env.example` to `.env` and fill in your credentials:
 ```
 VITE_SUPABASE_URL=your_supabase_url
 VITE_SUPABASE_ANON_KEY=your_supabase_key
+# Optional build metadata
+VITE_APP_ENV=production
+VITE_APP_VERSION=1.0.0
+# EmailJS integration (if used)
+VITE_EMAILJS_SERVICE_ID=
+VITE_EMAILJS_TEMPLATE_ID=
+VITE_EMAILJS_PUBLIC_KEY=
 ```
 
 ### Region Detection

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,10 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://jofuqlexuxzamltxxzuq.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImpvZnVxbGV4dXh6YW1sdHh4enVxIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDkxMDA2NjAsImV4cCI6MjA2NDY3NjY2MH0.Fq_Sx7NUeZF2k-erwrj_V-2npReXum9Cmuufsco3Cmw";
+// Supabase project credentials are loaded from environment variables so they can
+// be configured per deployment without code changes.
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";


### PR DESCRIPTION
## Summary
- document all environment variables
- add a `.env.example` file
- load Supabase credentials from environment variables

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68534f8ad8608320a49670d2273a1d4d